### PR TITLE
AKS 1.21 is no longer supported - bump to 1.24

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -83,7 +83,7 @@ function install() {
         echo "Finding Kubernetes version"
         AKS_VERSION=$(az aks get-versions \
           --location northeurope \
-          --query "orchestrators[?contains(orchestratorVersion, '1.21.')].orchestratorVersion" \
+          --query "orchestrators[?contains(orchestratorVersion, '1.24.')].orchestratorVersion" \
           -o json | jq -r '.[-1]')
       fi
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Kubernetes 1.21.x is no longer supported on Azure, so this bumps the versions to 1.24.x.

## How to test
<!-- Provide steps to test this PR -->
Run `make install`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
AKS 1.21 is no longer supported - bump to 1.24
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
